### PR TITLE
Cleanup: Component Interface

### DIFF
--- a/source/components/animation.d
+++ b/source/components/animation.d
@@ -4,7 +4,7 @@ import components.component, components.assetanimation;
 
 import gl3n.linalg;
 
-class Animation : Component
+class Animation : IComponent
 {
 private:
 	AssetAnimation _animationData;
@@ -20,23 +20,15 @@ public:
 
 	this( AssetAnimation assetAnimation)
 	{
-		super( null );
-
 		currentAnimation = 0;
 		currentPosition = 0.0f;
 		animationData = assetAnimation;
 		//currentPose = animationData.getPose();
 	}
 
-	override void update()
-	{
+	override void update() { }
 
-	}
-
-	override void shutdown()
-	{
-
-	}
+	override void shutdown() { }
 
 	class Bone
 	{

--- a/source/components/animation.d
+++ b/source/components/animation.d
@@ -1,6 +1,6 @@
 module components.animation;
 import core.properties;
-import components.component, components.assetanimation;
+import components.icomponent, components.assetanimation;
 
 import gl3n.linalg;
 

--- a/source/components/assetanimation.d
+++ b/source/components/assetanimation.d
@@ -1,6 +1,6 @@
 module components.assetanimation;
 import core.properties;
-import components.component;
+import components.icomponent;
 import utility.output;
 
 import derelict.assimp3.assimp;

--- a/source/components/camera.d
+++ b/source/components/camera.d
@@ -11,14 +11,9 @@ import std.conv;
 /**
  * Camera manages the viewmatrix and audio listeners for the world.
  */
-final class Camera : Component
+final class Camera : IComponent
 {
 public:
-	this()
-	{
-		super( null );
-	}
-
 	override void update() { }
 	override void shutdown() { }
 

--- a/source/components/component.d
+++ b/source/components/component.d
@@ -7,31 +7,25 @@ import core, graphics;
 /**
  * Interface for components to implement.
  */
-abstract class Component
+interface IComponent
 {
-private:
-	GameObject _owner;
-
 public:
 	/**
 	 * The GameObject that owns this component.
 	 */
-	mixin( Property!( _owner, AccessModifier.Public ) );
-
-	/**
-	 * Creates a Component and assigns the owner.
-	 */
-	this( GameObject owner )
+	final @property ref GameObject owner()
 	{
-		this.owner = owner;
+		static GameObject owner;
+		
+		return owner;
 	}
 
 	/**
 	 * Function called on update.
 	 */
-	abstract void update();
+	void update();
 	/**
 	 * Function called on shutdown.
 	 */
-	abstract void shutdown();
+	void shutdown();
 }

--- a/source/components/icomponent.d
+++ b/source/components/icomponent.d
@@ -1,7 +1,7 @@
 /**
  * Defines the Component abstract class, which is the base for all components.
  */
-module components.component;
+module components.icomponent;
 import core, graphics;
 
 /**

--- a/source/components/lights.d
+++ b/source/components/lights.d
@@ -3,7 +3,7 @@ import core, components, graphics;
 
 import gl3n.linalg;
 
-class Light : Component
+class Light : IComponent
 {
 private:
 	vec3 _color;
@@ -13,20 +13,12 @@ public:
 
 	this( vec3 color )
 	{
-		super( null );
-
 		this.color = color;
 	}
 	
-	override void update()
-	{
+	override void update() { }
 
-	}
-
-	override void shutdown()
-	{
-
-	}
+	override void shutdown() { }
 }
 
 class AmbientLight : Light 

--- a/source/components/material.d
+++ b/source/components/material.d
@@ -5,7 +5,7 @@ import yaml;
 import derelict.opengl3.gl3, derelict.freeimage.freeimage;
 import std.variant, std.conv;
 
-final class Material : Component
+final class Material : IComponent
 {
 private:
 	Texture _diffuse, _normal, _specular;
@@ -33,11 +33,6 @@ public:
 			obj.specular = Assets.get!Texture( prop.get!string );
 
 		return obj;
-	}
-
-	this()
-	{
-		super( null );
 	}
 
 	override void update() { }

--- a/source/components/mesh.d
+++ b/source/components/mesh.d
@@ -47,7 +47,7 @@ import std.stdio, std.stream, std.format, std.math;
 	Ogre XML
 	Q3D
  */
-class Mesh : Component
+class Mesh : IComponent
 {
 private:
 	uint _glVertexArray, _numVertices, _numIndices, _glIndexBuffer, _glVertexBuffer;
@@ -70,8 +70,6 @@ public:
 	 */
 	this( string filePath, const(aiMesh*) mesh )
 	{
-		super( null );
-
 		int floatsPerVertex, vertexSize;
 		float[] outputData;
 		uint[] indices;

--- a/source/components/package.d
+++ b/source/components/package.d
@@ -2,7 +2,7 @@ module components;
 public:
 import components.animation;
 import components.assetanimation;
-import components.component;
+import components.icomponent;
 import components.assets;
 import components.material;
 import components.mesh;

--- a/source/core/gameobject.d
+++ b/source/core/gameobject.d
@@ -45,18 +45,23 @@ public:
 	 * 
 	 * Params:
 	 * 	yamlObj =			The YAML node to pull info from.
+	 * 	scriptOverride =	The ClassInfo to use to create the object. Overrides YAML setting.
 	 * 
 	 * Returns:
 	 * 	A new game object with components and info pulled from yaml.
 	 */
-	static GameObject createFromYaml( Node yamlObj )
+	static GameObject createFromYaml( Node yamlObj, const ClassInfo scriptOverride = null )
 	{
 		GameObject obj;
 		Variant prop;
 		Node innerNode;
 
 		// Try to get from script
-		if( Config.tryGet!string( "Script.ClassName", prop, yamlObj ) )
+		if( scriptOverride !is null )
+		{
+			obj = cast(GameObject)scriptOverride.create();
+		}
+		else if( Config.tryGet!string( "Script.ClassName", prop, yamlObj ) )
 		{
 			const ClassInfo scriptClass = ClassInfo.find( prop.get!string );
 

--- a/source/core/gameobject.d
+++ b/source/core/gameobject.d
@@ -22,7 +22,7 @@ private:
 	Camera _camera;
 	GameObject _parent;
 	GameObject[] _children;
-	Component[ClassInfo] componentList;
+	IComponent[TypeInfo] componentList;
 
 public:
 	/// The current transform of the object.
@@ -182,9 +182,9 @@ public:
 	/**
 	 * Adds a component to the object.
 	 */
-	final void addComponent( T )( T newComponent ) if( is( T : Component ) )
+	final void addComponent( T )( T newComponent ) if( is( T : IComponent ) )
 	{
-		componentList[ T.classinfo ] = newComponent;
+		componentList[ typeid(T) ] = newComponent;
 
 		// Add component to proper property
 		if( typeid( newComponent ) == typeid( Material ) )


### PR DESCRIPTION
Switched to having component be an interface, that way components can inherit from other things as well. I also simplified creating prefabs substantially.

Closes #72.
