### PR TITLE
Feature: YAML Fields

### DIFF
--- a/source/core/gameobject.d
+++ b/source/core/gameobject.d
@@ -259,7 +259,7 @@ private shared Object function( Node )[string] getInitParams;
  * Type Params:
  * 	T =				The type onInitialize will recieve.
  */
-class GameObjectInit(T) : GameObject
+class GameObjectInit(T) : GameObject if( is( T == class ) )
 {
 	/// Function to override to get args from Fields field in YAML.
 	abstract void onInitialize( T args );

--- a/source/core/gameobject.d
+++ b/source/core/gameobject.d
@@ -253,6 +253,12 @@ public:
 
 private shared Object function( Node )[string] getInitParams;
 
+/**
+ * Class to extend when looking to use the onInitialize function.
+ * 
+ * Type Params:
+ * 	T =				The type onInitialize will recieve.
+ */
 class GameObjectInit(T) : GameObject
 {
 	/// Function to override to get args from Fields field in YAML.
@@ -264,6 +270,9 @@ class GameObjectInit(T) : GameObject
 		onInitialize( cast(T)o );
 	}
 
+	/**
+	 * Registers subclasses with onInit function pointers/
+	 */
 	shared static this()
 	{
 		foreach( mod; ModuleInfo )

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -221,7 +221,8 @@ public static:
 		foreach( memberName; __traits(derivedMembers, T) )
 		{
 			// If it is a field and not a function, tryGet it's value
-			static if( !__traits(compiles, ParameterTypeTuple!(__traits(getMember, toReturn, memberName))) )
+			static if( !__traits( compiles, ParameterTypeTuple!( __traits( getMember, toReturn, memberName ) ) ) &&
+			           !__traits( compiles, isBasicType!( __traits( getMember, toReturn, memberName ) ) ) )
 			{
 				tryGet( memberName, __traits(getMember, toReturn, memberName), node );
 			}


### PR DESCRIPTION
This allow for fields in GameObject's children to receive variables from YAML for initializing.

Naming for `GameObjectInit` is debatable.

See [feature/YAMLFields in Sample Dash Game](https://github.com/Circular-Studios/Sample-Dash-Game/tree/feature/YAMLVariables) for supporting code.

Also closes #101.
