### PR TITLE
Better error handling for fbo errors

### DIFF
--- a/source/graphics/adapters/adapter.d
+++ b/source/graphics/adapters/adapter.d
@@ -140,9 +140,25 @@ public:
         GLenum[ 2 ] DrawBuffers = [ GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 ];
         glDrawBuffers( 2, DrawBuffers.ptr );
 
-        if( auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE )
+        auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        if(status != GL_FRAMEBUFFER_COMPLETE )
         {
-            log( OutputType.Error, "Deffered rendering Frame Buffer was not initialized correctly. Error: ", status);
+            string mapFramebufferError(int code)
+            {
+                switch(code)
+                {
+                    case(GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT): return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
+                    case(GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT): return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
+                    case(GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER): return "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER";
+                    case(GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER): return "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER";
+                    case(GL_FRAMEBUFFER_UNSUPPORTED): return "GL_FRAMEBUFFER_UNSUPPORTED";
+                    case(GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE): return "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
+                    case(GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS): return "GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS";
+                    default: return "UNKNOWN";
+                }
+            }
+
+            log( OutputType.Error, "Deffered rendering Frame Buffer was not initialized correctly. Error: ", mapFramebufferError(status));
             assert(false);
         }
     }


### PR DESCRIPTION
If frame buffer doesn't pass check then status code is acquired which is transformed into man-readable string.
