### PR TITLE
Feature: New logging system

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -16,7 +16,8 @@
 		"derelict-fi": "~master",
 		"derelict-assimp3": "~master",
 		"dyaml": "~master",
-		"gl3n-shared" : "~master"
+		"gl3n-shared" : "~master",
+		"dlogg": ">=0.1.3"
 	},
 	"targetName": "dash",
 	"targetType": "library",

--- a/source/components/assetanimation.d
+++ b/source/components/assetanimation.d
@@ -56,7 +56,7 @@ public:
 
         if( id != -1 )
         {
-            log( OutputType.Warning, "Animation Node ");
+            log( LoggingLevel.Warning, "Animation Node ");
             node = new shared Node( name );
             node.id = id;
             node.transform = convertAIMatrix( mesh.mBones[ node.id ].mOffsetMatrix );

--- a/source/components/mesh.d
+++ b/source/components/mesh.d
@@ -124,7 +124,7 @@ public:
                 }
                 if( maxBonesAttached > 4 )
                 {
-                    log( OutputType.Warning, filePath, " has more than 4 bones for some vertex, data will be truncated. (has ", maxBonesAttached, ")" );
+                    log( LoggingLevel.Warning, filePath, " has more than 4 bones for some vertex, data will be truncated. (has ", maxBonesAttached, ")" );
                 }
 
                 // For each vertex on each face
@@ -213,7 +213,7 @@ public:
         else
         {
             // Did not load
-            log( OutputType.Error, "Mesh not loaded: ", filePath );
+            log( LoggingLevel.Fatal, "Mesh not loaded: ", filePath );
         }
         
         // make and bind the VAO

--- a/source/core/dgame.d
+++ b/source/core/dgame.d
@@ -180,6 +180,7 @@ private:
 
         logDebug( "Initializing..." );
         bench!( { Config.initialize(); } )( "Config init" );
+        bench!( { Logger.initialize(); } )( "Logger init" );
         bench!( { Input.initialize(); } )( "Input init" );
         bench!( { Output.initialize(); } )( "Output init" );
         bench!( { Graphics.initialize(); } )( "Graphics init" );

--- a/source/graphics/adapters/adapter.d
+++ b/source/graphics/adapters/adapter.d
@@ -158,7 +158,7 @@ public:
                 }
             }
 
-            log( OutputType.Error, "Deffered rendering Frame Buffer was not initialized correctly. Error: ", mapFramebufferError(status));
+            log( LoggingLevel.Fatal, "Deffered rendering Frame Buffer was not initialized correctly. Error: ", mapFramebufferError(status));
             assert(false);
         }
     }

--- a/source/graphics/shaders/shaders.d
+++ b/source/graphics/shaders/shaders.d
@@ -193,11 +193,11 @@ public:
         glGetShaderiv( vertexShaderID, GL_COMPILE_STATUS, &compileStatus );
         if( compileStatus != GL_TRUE )
         {
-            log( OutputType.Error, shaderName ~ " Vertex Shader compile error" );
+            log( LoggingLevel.Fatal, shaderName ~ " Vertex Shader compile error" );
             char[1000] errorLog;
             auto info = errorLog.ptr;
             glGetShaderInfoLog( vertexShaderID, 1000, null, info );
-            log( OutputType.Error, errorLog );
+            log( LoggingLevel.Fatal, errorLog );
             assert(false);
         }
 
@@ -205,11 +205,11 @@ public:
         glGetShaderiv( fragmentShaderID, GL_COMPILE_STATUS, &compileStatus );
         if( compileStatus != GL_TRUE )
         {
-            log( OutputType.Error, shaderName ~ " Fragment Shader compile error" );
+            log( LoggingLevel.Fatal, shaderName ~ " Fragment Shader compile error" );
             char[1000] errorLog;
             auto info = errorLog.ptr;
             glGetShaderInfoLog( fragmentShaderID, 1000, null, info );
-            log( OutputType.Error, errorLog );
+            log( LoggingLevel.Fatal, errorLog );
             assert(false);
         }
 
@@ -221,11 +221,11 @@ public:
         glGetProgramiv( programID, GL_LINK_STATUS, &compileStatus );
         if( compileStatus != GL_TRUE )
         {
-            log( OutputType.Error, shaderName ~ " Shader program linking error" );
+            log( LoggingLevel.Fatal, shaderName ~ " Shader program linking error" );
             char[1000] errorLog;
             auto info = errorLog.ptr;
             glGetProgramInfoLog( programID, 1000, null, info );
-            log( OutputType.Error, errorLog );
+            log( LoggingLevel.Fatal, errorLog );
             assert(false);
         }
     }

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -132,18 +132,27 @@ public:
     unittest
     {
         import std.stdio;
+        import std.exception;
+        
         writeln( "Dash Config get unittest" );
 
         auto n1 = Node( [ "test1": 10 ] );
 
         assert( Config.get!int( "test1", n1 ) == 10, "Config.get error." );
 
-        try
-        {
-            Config.get!int( "dontexist", n1 );
-            assert( false, "Config.get didn't throw." );
-        }
-        catch { }
+        assertThrown!Exception(Config.get!int( "dontexist", n1 ));
+        
+        // nested test
+        auto n2 = Node( ["test2": n1] );
+        auto n3 = Node( ["test3": n2] );
+        
+        assert( Config.get!int( "test3.test2.test1", n3 ) == 10, "Config.get nested test failed");
+        
+        auto n4 = Loader.fromString(
+            "test3:\n"
+            "   test2:\n"
+            "       test1: 10").load;
+        assert( Config.get!int( "test3.test2.test1", n4 ) == 10, "Config.get nested test failed");
     }
 
     /**

--- a/source/utility/filepath.d
+++ b/source/utility/filepath.d
@@ -55,7 +55,7 @@ public:
 
         if( !std.file.exists( safePath ) )
         {
-            log( OutputType.Info, path, " does not exist." );
+            log( LoggingLevel.Notice, path, " does not exist." );
             return [];
         }
 

--- a/source/utility/input.d
+++ b/source/utility/input.d
@@ -52,7 +52,7 @@ public:
                     }
                     catch
                     {
-                        log( OutputType.Error, "Failed to parse keybinding for input ", name );
+                        log( LoggingLevel.Fatal, "Failed to parse keybinding for input ", name );
                     }
                 }
             }
@@ -75,7 +75,7 @@ public:
                                 }
                                 catch
                                 {
-                                    log( OutputType.Error, "Failed to parse keybinding for input ", name );
+                                    log( LoggingLevel.Fatal, "Failed to parse keybinding for input ", name );
                                 }
                             }
 

--- a/source/utility/output.d
+++ b/source/utility/output.d
@@ -3,10 +3,17 @@
  */
 module utility.output;
 import utility.config;
-import std.stdio, std.functional;
+import dlogg.strict;
+import std.conv;
+import std.stdio;
+import std.functional;
+
+// to not import dlogg every time you call log function
+public import dlogg.log : LoggingLevel; 
 
 /**
  * The types of output.
+ * Deprecated: use $(B LoggingLevel).
  */
 enum OutputType
 {
@@ -26,6 +33,8 @@ enum OutputType
 enum Verbosity
 {
     /// Show me everything++.
+    /// Deprecated, debug msgs are cut off in release
+    /// version anyway. So equal High.
     Debug,
     /// Show me everything.
     High,
@@ -37,12 +46,43 @@ enum Verbosity
     Off,
 }
 
+/// Wrapper for logging into default logger instance
+/**
+*   Params:
+*   type     - level of logging
+*   messages - compile-time tuple of printable things
+*              to be written into the log.
+*/
+void log( A... )( LoggingLevel type, lazy A messages )
+{
+    Logger.log( messages.text, type );
+}
+/// Wrapper for logging with Notice level
+alias logNotice     = curry!( log, LoggingLevel.Notice );
+/// Alias for backward compatibility
+alias logInfo       = logNotice;
+/// Wrapper for logging with Warning level
+alias logWarning    = curry!( log, LoggingLevel.Warning );
+/// Wrapper for logging with Fatal level
+alias logFatal      = curry!( log, LoggingLevel.Fatal );
+/// Alias for backward compatibility
+alias logError      = logFatal;
+
+/// Special case is debug logging
+/**
+*   Debug messages are removed in release build.
+*/
+void logDebug( A... )( A messages )
+{
+    Logger.logDebug( messages );
+}
+
 /// Alias for Output.printMessage
-void log( A... )( OutputType type, A messages ) { Output.log( type, messages ); }
-alias logInfo       = curry!( log, OutputType.Info );
-alias logWarning    = curry!( log, OutputType.Warning );
-alias logError      = curry!( log, OutputType.Error );
-alias logDebug      = curry!( log, OutputType.Debug );
+deprecated("Use dlogg.log.LoggingLevel instead") 
+void log( A... )( OutputType type, A messages ) 
+{ 
+    Output.log( type, messages ); 
+}
 
 /**
  * Benchmark the running of a function, and log the result to the debug buffer.
@@ -57,15 +97,107 @@ void bench( alias func )( lazy string name )
     logDebug( name, " time:\t\t\t", cast(Duration)benchmark!func( 1 ) );
 }
 
+/// Global instance of logger
+shared GlobalLogger Logger;
+
+// Deprecated manager for console output
 shared OutputManager Output;
 
 shared static this()
 {
+    Logger = new shared GlobalLogger;
     Output = new shared OutputManager;
 }
 
 /**
- * Static class for handling interactions with the console.
+*   Children of StrictLogger with $(B initialize) method to
+*   handle loading verbosity from config.
+*/
+shared final class GlobalLogger : StrictLogger
+{
+    enum DEFAULT_LOG_NAME = "dash-preinit.log";
+    
+    this()
+    {
+        super(DEFAULT_LOG_NAME);
+    }
+    
+    /**
+    *   Loads verbosity from config.
+    */
+    final void initialize()
+    {
+        // Verbosity is more clearer for users than logging level
+        LoggingLevel mapVerbosity(Verbosity verbosity)
+        {
+            final switch(verbosity)
+            {
+                // Debug messages are cut off in release version any way
+                case(Verbosity.Debug):  return LoggingLevel.Notice;
+                case(Verbosity.High):   return LoggingLevel.Notice;
+                case(Verbosity.Medium): return LoggingLevel.Warning;
+                case(Verbosity.Low):    return LoggingLevel.Fatal;
+                case(Verbosity.Off):    return LoggingLevel.Muted;
+            }
+        }
+        
+        debug enum section = "Debug";
+        else  enum section = "Release";
+        
+        enum LognameSection = "Logging.FilePath";
+        enum OutputVerbositySection = "Logging."~section~".OutputVerbosity";
+        enum LoggingVerbositySection = "Logging."~section~".LoggingVerbosity";
+        
+        // Try to get new path for logging
+        string newFileName;
+        if( Config.tryGet!string( LognameSection, newFileName ) )
+        {
+            string oldFileName = this.name; 
+            try
+            {
+                this.name = newFileName;
+            } 
+            catch( Exception e )
+            {
+                std.stdio.writeln( "Error: Failed to reload new log location from '",oldFileName,"' to '",newFileName,"'" );
+                std.stdio.writeln( "Reason: ", e.msg );
+                debug std.stdio.writeln( e.toString );
+                
+                // Try to rollback
+                scope(failure) {} 
+                this.name = oldFileName;
+            }
+        }
+        
+        // Try to get output verbosity from config
+        Verbosity outputVerbosity;
+        if( Config.tryGet!Verbosity( OutputVerbositySection, outputVerbosity ) )
+        {
+            minOutputLevel = mapVerbosity( outputVerbosity ); 
+        } 
+        else
+        {
+            debug minOutputLevel = LoggingLevel.Notice;
+            else minOutputLevel = LoggingLevel.Warning; 
+        }
+        
+        // Try to get logging verbosity from config
+        Verbosity loggingVerbosity;
+        if( Config.tryGet!Verbosity( LoggingVerbositySection, loggingVerbosity ) )
+        {
+            minLoggingLevel = mapVerbosity( loggingVerbosity );
+        } 
+        else
+        {
+            debug minLoggingLevel = LoggingLevel.Notice;
+            else minLoggingLevel = LoggingLevel.Warning; 
+        }
+    }
+}
+
+/**
+ *  Static class for handling interactions with the console.
+ *  Deprecated: use GlobalLogger instead
  */
 shared final class OutputManager
 {
@@ -75,7 +207,8 @@ public:
      */
     final void initialize()
     {
-        verbosity = Config.get!Verbosity( "Game.Verbosity" );
+        verbosity = Verbosity.High;
+        Config.tryGet!Verbosity( "Game.Verbosity", verbosity );
     }
 
     /**


### PR DESCRIPTION
Original issue: https://github.com/Circular-Studios/Dash/issues/149
- Old staff is marked with 'deprecated'
- There are two phases: before loading a config (default config is used)
  and after config is loaded (logger could change logging file)
- There is feature to setup verbosity levels both for outputing to
  console and outputing to file
- Configuration is loaded in error-proof manner. All values are set to
  default if config cannot find them
- Fully qualified logging section in config:

``` YAML
Game:
    Verbosity: !Verbosity High # OutputManager 
Logging: # GlobalLogger options
    FilePath: "dash.log" # Phase 2 logname
    Debug: # Is taken in debug build
        OutputVerbosity: !Verbosity High
        LoggingVerbosity: !Verbosity High
    Release: # Is taken in release build
        OutputVerbosity: !Verbosity High
        LoggingVerbosity: !Verbosity High
```
