### PR TITLE
Feature: Single/Embedded YAML Document

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -25,7 +25,6 @@
 	"mainSourceFile": "source/app.d",
 	"sourcePaths": [ "source/" ],
 	"importPaths": [ "source/" ],
-	"stringImportPaths": [ "C:\\dev\\circular\\dash-game" ],
 	"libs-windows": [
 		"Awesomium"
 	],

--- a/dub.json
+++ b/dub.json
@@ -16,6 +16,7 @@
 		"derelict-fi": "~master",
 		"derelict-assimp3": "~master",
 		"dyaml": "~master",
+		"msgpack-d": "~master",
 		"gl3n-shared" : "~master",
 		"dlogg": ">=0.1.3"
 	},
@@ -24,6 +25,7 @@
 	"mainSourceFile": "source/app.d",
 	"sourcePaths": [ "source/" ],
 	"importPaths": [ "source/" ],
+	"stringImportPaths": [ "C:\\dev\\circular\\dash-game" ],
 	"libs-windows": [
 		"Awesomium"
 	],

--- a/dub.json
+++ b/dub.json
@@ -16,7 +16,6 @@
 		"derelict-fi": "~master",
 		"derelict-assimp3": "~master",
 		"dyaml": "~master",
-		"msgpack-d": "~master",
 		"gl3n-shared" : "~master",
 		"dlogg": ">=0.1.3"
 	},

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -22,7 +22,20 @@ private Node contentNode;
 private string fileToYaml( string filePath ) { return filePath.replace( "\\", "/" ).replace( "../", "" ).replace( "/", "." ); }
 
 version( ImportContent )
-private enum ContentYML = import( "Content.yml" );
+string contentYML;
+
+mixin template ContentImport()
+{
+    version( ImportContent )
+    {
+        static this()
+        {
+            import utility.config;
+            contentYML = import( "Content.yml" );
+        }
+        
+    }
+}
 
 /**
  * Process all yaml files in a directory.
@@ -148,8 +161,9 @@ public:
         version( ImportContent )
         {
             logDebug( "Using imported Content.yml file." );
+            assert( contentYML, "ImportContent version set, mixin not used." );
             import std.stream;
-            auto loader = Loader( new MemoryStream( cast(char[])ContentYML ) );
+            auto loader = Loader( new MemoryStream( cast(char[])contentYML ) );
             loader.constructor = constructor;
             contentNode = loader.load();
         }

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -74,11 +74,17 @@ Node[] loadYamlDocuments( string folder )
         auto fileNode = Config.get!Node( folder.fileToYaml, contentNode );
 
         foreach( string fileName, Node fileContent; fileNode )
+        {
             if( fileContent.isSequence )
+            {
                 foreach( Node childChild; fileContent )
                     nodes ~= childChild;
+            }
             else
+            {
                 nodes ~= fileContent;
+            }
+        }
     }
 
     return nodes;

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -21,17 +21,17 @@ import std.array, std.conv, std.string, std.path,
 private Node contentNode;
 private string fileToYaml( string filePath ) { return filePath.replace( "\\", "/" ).replace( "../", "" ).replace( "/", "." ); }
 
-version( ImportContent )
+version( EmbedContent )
 string contentYML;
 
 /**
  * Place this mixin anywhere in your game code to allow the Content.yml file
  * to be imported at compile time. Note that this will only actually import
- * the file when ImportContent is listed as a defined version.
+ * the file when EmbedContent is listed as a defined version.
  */
 mixin template ContentImport()
 {
-    version( ImportContent )
+    version( EmbedContent )
     {
         static this()
         {
@@ -169,10 +169,10 @@ public:
         //constructor.addConstructorScalar( "!Mesh", ( ref Node node ) => Assets.get!Mesh( node.get!string ) );
         //constructor.addConstructorScalar( "!Material", ( ref Node node ) => Assets.get!Material( node.get!string ) );
 
-        version( ImportContent )
+        version( EmbedContent )
         {
             logDebug( "Using imported Content.yml file." );
-            assert( contentYML, "ImportContent version set, mixin not used." );
+            assert( contentYML, "EmbedContent version set, mixin not used." );
             import std.stream;
             auto loader = Loader( new MemoryStream( cast(char[])contentYML ) );
             loader.constructor = constructor;

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -24,6 +24,11 @@ private string fileToYaml( string filePath ) { return filePath.replace( "\\", "/
 version( ImportContent )
 string contentYML;
 
+/**
+ * Place this mixin anywhere in your game code to allow the Content.yml file
+ * to be imported at compile time. Note that this will only actually import
+ * the file when ImportContent is listed as a defined version.
+ */
 mixin template ContentImport()
 {
     version( ImportContent )

--- a/source/utility/config.d
+++ b/source/utility/config.d
@@ -70,7 +70,7 @@ T[] loadYamlObjects( T )( string folder )
  */
 Node loadYamlFile( string filePath )
 {
-    auto loader = Loader( filePath );
+    auto loader = Loader( filePath ~ ".yml" );
     loader.constructor = Config.constructor;
     try
     {

--- a/source/utility/filepath.d
+++ b/source/utility/filepath.d
@@ -43,6 +43,7 @@ public:
         ConfigDir = ResourceHome ~ "/Config",
         ConfigFile = ConfigDir ~ "/Config",
         InputBindings = ConfigDir ~ "/Input", 
+        CompactContentFile = ResourceHome ~ "/Content",
     }
 
     /**

--- a/source/utility/filepath.d
+++ b/source/utility/filepath.d
@@ -41,8 +41,8 @@ public:
         Shaders = ResourceHome ~ "/Shaders",
         UI = ResourceHome ~ "/UI",
         ConfigDir = ResourceHome ~ "/Config",
-        ConfigFile = ConfigDir ~ "/Config.yml",
-        InputBindings = ConfigDir ~ "/Input.yml", 
+        ConfigFile = ConfigDir ~ "/Config",
+        InputBindings = ConfigDir ~ "/Input", 
     }
 
     /**


### PR DESCRIPTION
This adds 2 major features to the YAML loading system:
1. All content can now be consolidated to a single `Content.yml` file. This is good for preparing for releases, as well as small games with little content.
2. The single YAML file can be embedded in the executable. This is done by adding `"versions": [ "ImportContent"]` to the `dub.json` file, and making sure to set `stringImportPaths` to the location of `Content.yml`. The advantage of this is that it means only art assets (textures and meshes) need to be distributed along side the game. This means that modding will become very difficult (unless purposefully left easy).

See the [`feature/SingleYamlDocument`](https://github.com/Circular-Studios/Sample-Dash-Game/compare/feature;SingleYamlDocument) branch in sample game for more info.
