### PR TITLE
Custom style for Global logger.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -17,7 +17,7 @@
 		"derelict-assimp3": "~master",
 		"dyaml": "~master",
 		"gl3n-shared" : "~master",
-		"dlogg": ">=0.2.1",
+		"dlogg": ">=0.2.2",
 		"x11": { "version": "==1.0.0", "optional": true }
 	},
 	"targetName": "dash",

--- a/dub.json
+++ b/dub.json
@@ -17,7 +17,7 @@
 		"derelict-assimp3": "~master",
 		"dyaml": "~master",
 		"gl3n-shared" : "~master",
-		"dlogg": ">=0.1.3",
+		"dlogg": ">=0.2.1",
 		"x11": { "version": "==1.0.0", "optional": true }
 	},
 	"targetName": "dash",

--- a/source/utility/output.d
+++ b/source/utility/output.d
@@ -8,23 +8,23 @@ import std.conv;
 import std.stdio;
 import std.functional;
 
-// to not import dlogg every time you call log function
-public import dlogg.log : LoggingLevel; 
-
 /**
- * The types of output.
- * Deprecated: use $(B LoggingLevel).
- */
+*   Custom logging level type for global logger.
+*/
 enum OutputType
 {
-    /// Info for developers.
+    /// Debug messages, aren't compiled in release version
     Debug,
-    /// Purely informational.
+    /// Diagnostic messages about program state
     Info,
-    /// Something went wrong, but it's recoverable.
+    /// Non fatal errors
     Warning,
-    /// The ship is sinking.
+    /// Fatal errors that usually stop application
     Error,
+    /// Messages of the level don't go to output.
+    /// That used with minLoggingLevel and minOutputLevel
+    /// to suppress any message. 
+    Muted
 }
 
 /**
@@ -33,8 +33,8 @@ enum OutputType
 enum Verbosity
 {
     /// Show me everything++.
-    /// Deprecated, debug msgs are cut off in release
-    /// version anyway. So equal High.
+    /// Debug msgs are cut off in release
+    /// version.
     Debug,
     /// Show me everything.
     High,
@@ -53,20 +53,18 @@ enum Verbosity
 *   messages - compile-time tuple of printable things
 *              to be written into the log.
 */
-void log( A... )( LoggingLevel type, lazy A messages )
+void log( A... )( OutputType type, lazy A messages )
 {
     Logger.log( messages.text, type );
 }
-/// Wrapper for logging with Notice level
-alias logNotice     = curry!( log, LoggingLevel.Notice );
-/// Alias for backward compatibility
-alias logInfo       = logNotice;
+/// Wrapper for logging with Info level
+alias logInfo     = curry!( log, OutputType.Info );
+alias logNotice   = logInfo;
 /// Wrapper for logging with Warning level
-alias logWarning    = curry!( log, LoggingLevel.Warning );
-/// Wrapper for logging with Fatal level
-alias logFatal      = curry!( log, LoggingLevel.Fatal );
-/// Alias for backward compatibility
-alias logError      = logFatal;
+alias logWarning    = curry!( log, OutputType.Warning );
+/// Wrapper for logging with Error level
+alias logError      = curry!( log, OutputType.Error );
+alias logFatal      = logError;
 
 /// Special case is debug logging
 /**
@@ -74,7 +72,7 @@ alias logError      = logFatal;
 */
 void logDebug( A... )( A messages )
 {
-    Logger.logDebug( messages );
+   debug Logger.log( messages.text, OutputType.Debug );
 }
 
 /**
@@ -99,10 +97,18 @@ shared static this()
 }
 
 /**
-*   Children of StrictLogger with $(B initialize) method to
+*   Children of StyledStrictLogger with $(B initialize) method to
 *   handle loading verbosity from config.
+*
+*   Overwrites default style to use with local OutputType.
 */
-shared final class GlobalLogger : StrictLogger
+shared final class GlobalLogger : StyledStrictLogger!(OutputType
+                , OutputType.Debug,   "Debug: %1$s",   "[%2$s] Debug: %1$s"
+                , OutputType.Info,    "Info: %1$s",    "[%2$s] Info: %1$s"
+                , OutputType.Warning, "Warning: %1$s", "[%2$s] Warning: %1$s"
+                , OutputType.Error,   "Error: %1$s",   "[%2$s] Error: %1$s"
+                , OutputType.Muted,   "",              ""
+                )
 {
     enum DEFAULT_LOG_NAME = "dash-preinit.log";
     
@@ -116,20 +122,6 @@ shared final class GlobalLogger : StrictLogger
     */
     final void initialize()
     {
-        // Verbosity is more clearer for users than logging level
-        LoggingLevel mapVerbosity(Verbosity verbosity)
-        {
-            final switch(verbosity)
-            {
-                // Debug messages are cut off in release version any way
-                case(Verbosity.Debug):  return LoggingLevel.Notice;
-                case(Verbosity.High):   return LoggingLevel.Notice;
-                case(Verbosity.Medium): return LoggingLevel.Warning;
-                case(Verbosity.Low):    return LoggingLevel.Fatal;
-                case(Verbosity.Off):    return LoggingLevel.Muted;
-            }
-        }
-        
         debug enum section = "Debug";
         else  enum section = "Release";
         
@@ -162,24 +154,24 @@ shared final class GlobalLogger : StrictLogger
         Verbosity outputVerbosity;
         if( Config.tryGet!Verbosity( OutputVerbositySection, outputVerbosity ) )
         {
-            minOutputLevel = mapVerbosity( outputVerbosity ); 
+            minOutputLevel = cast(OutputType)( outputVerbosity ); 
         } 
         else
         {
-            debug minOutputLevel = LoggingLevel.Notice;
-            else minOutputLevel = LoggingLevel.Warning; 
+            debug minOutputLevel = OutputType.Info;
+            else minOutputLevel = OutputType.Warning; 
         }
         
         // Try to get logging verbosity from config
         Verbosity loggingVerbosity;
         if( Config.tryGet!Verbosity( LoggingVerbositySection, loggingVerbosity ) )
         {
-            minLoggingLevel = mapVerbosity( loggingVerbosity );
+            minLoggingLevel = cast(OutputType)( loggingVerbosity );
         } 
         else
         {
-            debug minLoggingLevel = LoggingLevel.Notice;
-            else minLoggingLevel = LoggingLevel.Warning; 
+            debug minLoggingLevel = OutputType.Info;
+            else minLoggingLevel = OutputType.Warning; 
         }
     }
 }


### PR DESCRIPTION
Related to #163.
- Debug msgs have highest verbosity.
- With new styling API users can define custom logging levels. `OutputType` is reinstated to be used with logging system.
