### PR TITLE
Feature: Behaviors

### DIFF
--- a/source/components/behavior.d
+++ b/source/components/behavior.d
@@ -65,7 +65,6 @@ abstract shared class Behavior( InitType = void ) : ABehavior
                     if( klass.base == typeid(Behavior!InitType) )
                     {
                         getInitParams[ klass.name ] = &Config.getObject!InitType;
-                        return;
                     }
                 }
             }

--- a/source/components/behavior.d
+++ b/source/components/behavior.d
@@ -86,7 +86,7 @@ private shared Object function( Node )[string] getInitParams;
 /**
  * Defines a collection of Behaviors to allow for multiple scripts to be added to an object.
  */
-final shared class Behaviors
+shared struct Behaviors
 {
 private:
     ABehavior[] behaviors;

--- a/source/components/behavior.d
+++ b/source/components/behavior.d
@@ -1,0 +1,115 @@
+/**
+ * Defines Behavior class, the base class for all scripts.
+ */
+module components.behavior;
+import utility;
+
+import yaml;
+import std.algorithm, std.array;
+
+/**
+ * Defines methods for child classes to override.
+ */
+private abstract shared class ABehavior
+{
+    protected void initializeBehavior( Object param ) {  }
+    /// Called on the update cycle.
+    void onUpdate() { }
+    /// Called on the draw cycle.
+    void onDraw() { }
+    /// Called on shutdown.
+    void onShutdown() { }
+}
+
+/**
+ * Defines methods for child classes to override, with a parameter for onInitialize.
+ *
+ * Params:
+ *  InitType =          The type for onInitialize to take.
+ */
+abstract shared class Behavior( InitType = void ) : ABehavior
+{
+    static if( is( InitType == void ) )
+    {
+        void onInitialize() { }
+    }
+    else
+    {
+        void onInitialize( InitType ) { }
+        private final override initializeBehavior( Object param )
+        {
+            onInitialize( cast(InitType)param );
+        }
+    }
+
+    /**
+     * Registers subclasses with onInit function pointers/
+     */
+    shared static this()
+    {
+        static if( !is( InitType == void ) )
+        {
+            foreach( mod; ModuleInfo )
+            {
+                foreach( klass; mod.localClasses )
+                {
+                    if( klass.base == typeid(Behavior!T) )
+                    {
+                        getInitParams[ klass.name ] = &Config.getObject!T;
+                    }
+                }
+            }
+        }
+    }
+}
+
+private shared Object function( Node )[string] getInitParams;
+
+/**
+ * Defines a collection of Behaviors to allow for multiple scripts to be added to an object.
+ */
+final shared class Behaviors
+{
+private:
+    ABehavior[] behaviors;
+
+public:
+    /**
+     * Adds a new behavior to the collection.
+     *
+     * Params:
+     *  newBehavior =   The behavior to add to the object.
+     */
+    void createBehavior( string className, Node fields = Node( YAMLNull() ) )
+    {
+        auto newBehavior = cast(shared ABehavior)Object.factory( className );
+
+        if( !newBehavior )
+        {
+            logWarning( "Class ", className, " either not found or not child of Behavior." );
+            return;
+        }
+
+        if( !fields.isNull && className in getInitParams )
+        {
+            newBehavior.initializeBehavior( getInitParams[ className ]( fields ) );
+        }
+        else
+        {
+            newBehavior.initializeBehavior( null );
+        }
+
+        behaviors ~= newBehavior;
+    }
+
+    mixin( callBehaviors );
+}
+
+enum callBehaviors = "".reduce!( ( a, func ) => a ~
+    q{
+        void $func()
+        {
+            foreach( script; behaviors )
+                script.$func();
+        }
+    }.replace( "$func", func ) )( ( cast(string[])[__traits( derivedMembers, ABehavior )] )[ 1..$ ] );

--- a/source/components/behavior.d
+++ b/source/components/behavior.d
@@ -82,18 +82,30 @@ shared struct Behaviors
 {
 private:
     ABehavior[] behaviors;
+    shared GameObject _owner;
 
 public:
+    /**
+     * Constructor for Behaviors which assigns its owner.
+     *
+     * Params:
+     *  owner =         The owner of this behavior set.
+     */
+    this( shared GameObject owner )
+    {
+        _owner = owner;
+    }
+
     /**
      * Adds a new behavior to the collection.
      *
      * Params:
      *  newBehavior =   The behavior to add to the object.
      */
-    void createBehavior( shared GameObject owner, string className, Node fields = Node( YAMLNull() ) )
+    void createBehavior( string className, Node fields = Node( YAMLNull() ) )
     {
         auto newBehavior = cast(shared ABehavior)Object.factory( className );
-        newBehavior._owner = owner;
+        newBehavior._owner = _owner;
 
         if( !newBehavior )
         {
@@ -118,10 +130,10 @@ public:
 
 enum callBehaviors = "".reduce!( ( a, func ) => a ~
     q{
-        void $func()
+        static if( __traits( compiles, ParameterTypeTuple!( __traits( getMember, ABehavior, "$func") ) ) &&
+                    ParameterTypeTuple!( __traits( getMember, ABehavior, "$func") ).length == 0 )
         {
-            static if( __traits( compiles, ParameterTypeTuple!( __traits( getMember, "$func") ) ) &&
-                        ParameterTypeTuple!( __traits( getMember, "$func") ).length == 0 )
+            void $func()
             {
                 foreach( script; behaviors )
                 {

--- a/source/components/behavior.d
+++ b/source/components/behavior.d
@@ -17,6 +17,8 @@ private abstract shared class ABehavior
     /// Function called by Behaviors to init the object.
     /// Should not be touched by anything outside this module.
     protected void initializeBehavior( Object param ) {  }
+    /// The function called on initialization of the object.
+    void onInitialize() { }
     /// Called on the update cycle.
     void onUpdate() { }
     /// Called on the draw cycle.
@@ -33,27 +35,17 @@ private abstract shared class ABehavior
  */
 abstract shared class Behavior( InitType = void ) : ABehavior
 {
-    static if( is( InitType == void ) )
+    static if( !is( InitType == void ) )
     {
-        /**
-         * The function called on initialization of the object.
-         */
-        void onInitialize() { }
-        protected final override void initializeBehavior( Object param ) { onInitialize(); }
+        InitType initArgs;
+        protected final override void initializeBehavior( Object param )
+        {
+            initArgs = cast(shared InitType)param;
+        }
     }
     else
     {
-        /**
-         * The function called on initialization of the object.
-         *
-         * Params:
-         *  arg =       The args defined by the object.
-         */
-        void onInitialize( InitType arg ) { }
-        protected final override void initializeBehavior( Object param )
-        {
-            onInitialize( cast(InitType)param );
-        }
+        protected final override void initializeBehavior( Object param ) { onInitialize(); }
     }
 
     /// Returns the GameObject which owns this behavior.

--- a/source/components/behavior.d
+++ b/source/components/behavior.d
@@ -16,7 +16,7 @@ private abstract shared class ABehavior
     private GameObject _owner;
     /// Function called by Behaviors to init the object.
     /// Should not be touched by anything outside this module.
-    protected void initializeBehavior( Object param ) {  }
+    protected void initializeBehavior( Object param ) { }
     /// The function called on initialization of the object.
     void onInitialize() { }
     /// Called on the update cycle.
@@ -42,10 +42,6 @@ abstract shared class Behavior( InitType = void ) : ABehavior
         {
             initArgs = cast(shared InitType)param;
         }
-    }
-    else
-    {
-        protected final override void initializeBehavior( Object param ) { onInitialize(); }
     }
 
     /// Returns the GameObject which owns this behavior.
@@ -115,10 +111,6 @@ public:
         if( !fields.isNull && className in getInitParams )
         {
             newBehavior.initializeBehavior( getInitParams[ className ]( fields ) );
-        }
-        else
-        {
-            newBehavior.initializeBehavior( null );
         }
 
         behaviors ~= newBehavior;

--- a/source/components/package.d
+++ b/source/components/package.d
@@ -8,3 +8,4 @@ import components.mesh;
 import components.camera;
 import components.lights;
 import components.userinterface;
+import components.behavior;

--- a/source/core/gameobject.d
+++ b/source/core/gameobject.d
@@ -385,7 +385,7 @@ class GameObjectInit(T) : GameObject if( is( T == class ) )
     }
 
     /**
-     * Registers subclasses with onInit function pointers/
+     * Registers subclasses with onInit function pointers.
      */
     shared static this()
     {

--- a/source/core/gameobject.d
+++ b/source/core/gameobject.d
@@ -196,6 +196,8 @@ public:
                 logWarning( "Unknown key: ", key );
         }
 
+        obj.behaviors.onInitialize();
+
         return obj;
     }
 

--- a/source/core/prefabs.d
+++ b/source/core/prefabs.d
@@ -70,9 +70,9 @@ public:
      * Returns:
      *  The new GameObject from the Prefab.
      */
-    final shared(GameObject) createInstance( const ClassInfo scriptOverride = null )
+    final shared(GameObject) createInstance()
     {
-        return GameObject.createFromYaml( yaml, scriptOverride );
+        return GameObject.createFromYaml( yaml );
     }
 
 private:


### PR DESCRIPTION
This moves game object logic out of `GameObjects` children, and into children of `Behavior`. This does a number of things for us:
- `GameObject.createFromYaml` becomes much much simpler.
- An object can have multiple `Behavior`s on it.
- A `Behavior` can be added to an object after it is initialized.
- Scripts that don't take `onInitialize` arguments can now actually have an `onInitialize` method that is called after all yaml loading is complete.
- Decoupling scripts and objects paves the way for a polymorphic scripting system.

Down sides:
- This is very much a code breaking change. You can see the required changes to Sample Game [here](https://github.com/Circular-Studios/Sample-Dash-Game/compare/feature;Behaviors).
