### PR TITLE
Feature: Flywheightening

### DIFF
--- a/source/dash/components/animation.d
+++ b/source/dash/components/animation.d
@@ -18,7 +18,7 @@ class Animation : Component
 {
 private:
     /// Asset animation that the gameobject is animating based off of
-    AssetAnimation _animationData;
+    AnimationData _animationData;
     /// Current animation out of all the animations in the asset animation
     int _currentAnim;
     /// Current time of the animation
@@ -40,7 +40,7 @@ public:
     /**
      * Create animation object based on asset animation
      */
-    this( AssetAnimation assetAnimation )
+    this( AnimationData assetAnimation )
     {
         _currentAnim = 0;
         _currentAnimTime = 0.0f;
@@ -137,7 +137,7 @@ public:
 /**
  * Stores the animation skeleton/bones, stores the animations poses, and makes this information accessible to gameobjects
  */
-class AssetAnimation : Asset
+class AnimationData : Asset
 {
 private:
     /// List of animations, containing all of the information specific to each

--- a/source/dash/components/animation.d
+++ b/source/dash/components/animation.d
@@ -3,7 +3,7 @@
  */
 module dash.components.animation;
 import dash.core.properties;
-import dash.components.component;
+import dash.components;
 import dash.utility;
 
 import derelict.assimp3.assimp;
@@ -137,7 +137,7 @@ public:
 /**
  * Stores the animation skeleton/bones, stores the animations poses, and makes this information accessible to gameobjects
  */
-class AssetAnimation
+class AssetAnimation : Asset
 {
 private:
     /// List of animations, containing all of the information specific to each
@@ -167,6 +167,8 @@ public:
      */
     this( const(aiAnimation**) animations, int numAnimations, const(aiMesh*) mesh, const(aiNode*) nodeHierarchy )
     {
+        super( Resource( "" ) );
+
         for( int i = 0; i < nodeHierarchy.mNumChildren; i++)
         {
             string name = nodeHierarchy.mChildren[ i ].mName.data.ptr.fromStringz().to!string;
@@ -446,7 +448,7 @@ public:
     /**
      * Shutdown the animation bone/pose data
      */
-    void shutdown()
+    override void shutdown()
     {
 
     }

--- a/source/dash/components/assets.d
+++ b/source/dash/components/assets.d
@@ -32,7 +32,9 @@ public:
      */
     AssetRefT get( AssetRefT )( string name ) if( is( AssetRefT AssetT : AssetRef!AssetT ) && !is( AssetRefT == AssetRef!AssetT ) )
     {
-        return new AssetRefT( get!AssetT( name ) );
+        static if( is( AssetRefT AssetT : AssetRef!AssetT ) )
+            return new AssetRefT( getAsset!AssetT( name ) );
+        else static assert( false );
     }
 
     /**
@@ -75,11 +77,11 @@ public:
         assert(aiIsExtensionSupported(".fbx".toStringz), "fbx format isn't supported by assimp instance!");
 
         // Load the unitSquare
-        unitSquare = new MeshAsset( "", aiImportFileFromMemory(
-                                        unitSquareMesh.toStringz, unitSquareMesh.length,
+        unitSquare = new Mesh( new MeshAsset( "", aiImportFileFromMemory(
+                                        unitSquareMesh.toStringz(), unitSquareMesh.length,
                                         aiProcess_CalcTangentSpace | aiProcess_Triangulate |
                                         aiProcess_JoinIdenticalVertices | aiProcess_SortByPType,
-                                        "obj" ).mMeshes[0] );
+                                        "obj" ).mMeshes[0] ) );
 
         foreach( file; scanDirectory( Resources.Meshes ) )
         {
@@ -128,7 +130,7 @@ public:
             if( name in materials )
                 logWarning( "Material ", name, " exists more than once." );
 
-            auto newMat = cast(Material)createYamlObject[ "Material" ]( object );
+            auto newMat = cast(MaterialAsset)createYamlObject[ "Material" ]( object );
             materials[ name ] = newMat;
             materialResources[ objFile[ 1 ] ] ~= newMat;
         }

--- a/source/dash/components/assets.d
+++ b/source/dash/components/assets.d
@@ -16,24 +16,32 @@ abstract final class Assets
 {
 static:
 private:
-    Material[][Resource] materialResources;
+    MaterialAsset[][Resource] materialResources;
 
 package:
-    Mesh[string] meshes;
-    Texture[string] textures;
-    Material[string] materials;
+    MeshAsset[string] meshes;
+    TextureAsset[string] textures;
+    MaterialAsset[string] materials;
 
 public:
     /// Basic quad, generally used for billboarding.
     Mesh unitSquare;
 
     /**
+     * Get a reference to the asset with the given type and name.
+     */
+    AssetRefT get( AssetRefT )( string name ) if( is( AssetRefT AssetT : AssetRef!AssetT ) && !is( AssetRefT == AssetRef!AssetT ) )
+    {
+        return new AssetRefT( get!AssetT( name ) );
+    }
+
+    /**
      * Get the asset with the given type and name.
      */
-    T get( T )( string name ) if( is( T == Mesh ) || is( T == Texture ) || is( T == Material ) || is( T == AssetAnimation ))
+    AssetT getAsset( AssetT )( string name ) if( is( AssetT : Asset ) )
     {
         enum get( Type, string array ) = q{
-            static if( is( T == $Type ) )
+            static if( is( AssetT == $Type ) )
             {
                 if( auto result = name in $array )
                 {
@@ -48,9 +56,9 @@ public:
             }
         }.replaceMap( [ "$array": array, "$Type": Type.stringof ] );
 
-        mixin( get!( Mesh, q{meshes} ) );
-        mixin( get!( Texture, q{textures} ) );
-        mixin( get!( Material, q{materials} ) );
+        mixin( get!( MeshAsset, q{meshes} ) );
+        mixin( get!( TextureAsset, q{textures} ) );
+        mixin( get!( MaterialAsset, q{materials} ) );
     }
 
     /**
@@ -67,7 +75,7 @@ public:
         assert(aiIsExtensionSupported(".fbx".toStringz), "fbx format isn't supported by assimp instance!");
 
         // Load the unitSquare
-        unitSquare = new Mesh( "", aiImportFileFromMemory(
+        unitSquare = new MeshAsset( "", aiImportFileFromMemory(
                                         unitSquareMesh.toStringz, unitSquareMesh.length,
                                         aiProcess_CalcTangentSpace | aiProcess_Triangulate |
                                         aiProcess_JoinIdenticalVertices | aiProcess_SortByPType,
@@ -88,7 +96,7 @@ public:
             // Add mesh
             if( scene.mNumMeshes > 0 )
             {
-                auto newMesh = new Mesh( file.fullPath, scene.mMeshes[ 0 ] );
+                auto newMesh = new MeshAsset( file.fullPath, scene.mMeshes[ 0 ] );
 
                 if( scene.mNumAnimations > 0 )
                     newMesh.animationData = new AssetAnimation( scene.mAnimations, scene.mNumAnimations, scene.mMeshes[ 0 ], scene.mRootNode );
@@ -109,7 +117,7 @@ public:
             if( file.baseFileName in textures )
                logWarning( "Texture ", file.baseFileName, " exists more than once." );
 
-            textures[ file.baseFileName ] = new Texture( file.fullPath );
+            textures[ file.baseFileName ] = new TextureAsset( file.fullPath );
         }
 
         foreach( objFile; loadYamlFiles( Resources.Materials ) )
@@ -158,7 +166,7 @@ public:
 
         // Iterate over each file, and it's materials
         refreshYamlObjects!(
-            node => cast(Material)createYamlObject[ "Material" ]( node ),
+            node => cast(MaterialAsset)createYamlObject[ "Material" ]( node ),
             node => node[ "Name" ].get!string in materials,
             ( node, mat ) => materials[ node[ "Name" ].get!string ] = mat,
             mat => materials.remove( mat.name ) )
@@ -187,24 +195,54 @@ public:
     }
 }
 
-abstract class Asset : Component
+abstract class Asset
 {
 private:
     bool _isUsed;
-    Resource _resource;
 
 public:
     /// Whether or not the material is actually used.
     mixin( Property!( _isUsed, AccessModifier.Package ) );
     /// The resource containing this asset.
-    mixin( RefGetter!_resource );
+    Resource resource;
 
     /**
      * Creates asset with resource.
      */
-    this( Resource resource )
+    this( Resource res )
     {
-        _resource = resource;
+        resource = res;
+    }
+
+    void initialize() { }
+    void update() { }
+    void refresh() { }
+    void shutdown() { }
+}
+
+/**
+ * A reference to an asset.
+ */
+abstract class AssetRef( AssetType ) : Component if( is( AssetType : Asset ) )
+{
+public:
+    //@ignore
+    AssetType asset;
+
+    @field( "Asset" )
+    string assetName;
+
+    this() { }
+    this( AssetType ass )
+    {
+        asset = ass;
+    }
+
+    /// Gets a reference to it's asset.
+    override void initialize()
+    {
+        if( !asset )
+            asset = Assets.getAsset!AssetType( assetName );
     }
 }
 

--- a/source/dash/components/assets.d
+++ b/source/dash/components/assets.d
@@ -99,7 +99,7 @@ public:
                 auto newMesh = new MeshAsset( file.fullPath, scene.mMeshes[ 0 ] );
 
                 if( scene.mNumAnimations > 0 )
-                    newMesh.animationData = new AssetAnimation( scene.mAnimations, scene.mNumAnimations, scene.mMeshes[ 0 ], scene.mRootNode );
+                    newMesh.animationData = new AnimationData( scene.mAnimations, scene.mNumAnimations, scene.mMeshes[ 0 ], scene.mRootNode );
 
                 meshes[ file.baseFileName ] = newMesh;
             }

--- a/source/dash/components/component.d
+++ b/source/dash/components/component.d
@@ -101,11 +101,11 @@ auto field( string loader = "null" )( string name = "" )
 }
 
 /// Used to create objects from yaml. The key is the YAML name of the type.
-YamlObject delegate( Node )[string] createYamlObject;
+Object delegate( Node )[string] createYamlObject;
 /// Used to create components from yaml. The key is the YAML name of the type.
 Component delegate( Node )[string] createYamlComponent;
 /// Refresh any object defined from yaml. The key is the typeid of the type.
-void delegate( YamlObject, Node )[TypeInfo] refreshYamlObject;
+void delegate( Object, Node )[TypeInfo] refreshYamlObject;
 
 /**
  * To be placed at the top of any module defining YamlComponents.
@@ -165,7 +165,7 @@ enum registerComponents( string modName ) = q{
 LoaderFunction[TypeInfo] typeLoaders;
 
 /// DON'T MIND ME
-void registerYamlObjects( Base )( string yamlName, YamlType type ) if( is( Base : YamlObject ) )
+void registerYamlObjects( Base )( string yamlName, YamlType type ) if( isYamlObject!Base )
 {
     // If no name specified, use class name.
     if( yamlName == "" )
@@ -341,7 +341,7 @@ void registerYamlObjects( Base )( string yamlName, YamlType type ) if( is( Base 
             createYamlObject[ yamlName ] = ( node )
             {
                 // Create an instance of the class to assign things to.
-                YamlObject b = new Base;
+                Object b = new Base;
 
                 refreshYamlObject[ typeid(Base) ]( b, node );
 

--- a/source/dash/components/material.d
+++ b/source/dash/components/material.d
@@ -86,7 +86,8 @@ final class Material : AssetRef!MaterialAsset
         super.initialize();
 
         // All materials should be unique.
-        asset = asset.clone();
+        if( asset )
+            asset = asset.clone();
     }
 }
 
@@ -192,6 +193,11 @@ private:
 class Texture : AssetRef!TextureAsset
 {
     alias asset this;
+
+    this( TextureAsset ass )
+    {
+        super( ass );
+    }
 }
 
 /**
@@ -202,7 +208,7 @@ class Texture : AssetRef!TextureAsset
     static Texture def;
 
     if( !def )
-        def = new TextureAsset( [cast(ubyte)0, cast(ubyte)0, cast(ubyte)0, cast(ubyte)255].ptr );
+        def = new Texture( new TextureAsset( [cast(ubyte)0, cast(ubyte)0, cast(ubyte)0, cast(ubyte)255].ptr ) );
 
     return def;
 }
@@ -215,7 +221,7 @@ class Texture : AssetRef!TextureAsset
     static Texture def;
 
     if( !def )
-        def = new TextureAsset( [cast(ubyte)255, cast(ubyte)127, cast(ubyte)127, cast(ubyte)255].ptr );
+        def = new Texture( new TextureAsset( [cast(ubyte)255, cast(ubyte)127, cast(ubyte)127, cast(ubyte)255].ptr ) );
 
     return def;
 }

--- a/source/dash/components/material.d
+++ b/source/dash/components/material.d
@@ -13,15 +13,16 @@ mixin( registerComponents!q{dash.components.material} );
 /**
  * A collection of textures that serve different purposes in the rendering pipeline.
  */
-@yamlComponent!( q{name => Assets.get!Material( name )} )()
 @yamlObject()
-final class Material : Asset
+final class MaterialAsset : Asset
 {
 package:
     @field( "Name" )
     string _name;
 
 public:
+    /// The defining yaml
+    Node yaml;
     /// The diffuse (or color) map.
     @field( "Diffuse" )
     Texture diffuse;
@@ -46,6 +47,19 @@ public:
     }
 
     /**
+     * Duplicate the material.
+     */
+    MaterialAsset clone()
+    {
+        auto mat = new MaterialAsset;
+        mat.diffuse = diffuse;
+        mat.normal = normal;
+        mat.specular = specular;
+        mat._name = _name;
+        return mat;
+    }
+
+    /**
      * Shuts down the material, making sure all references are released.
      */
     override void shutdown()
@@ -55,10 +69,31 @@ public:
 }
 
 /**
+ * A reference to a material.
+ */
+final class Material : AssetRef!MaterialAsset
+{
+    alias asset this;
+
+    this() { }
+    this( MaterialAsset ass )
+    {
+        super( ass );
+    }
+
+    override void initialize()
+    {
+        super.initialize();
+
+        // All materials should be unique.
+        asset = asset.clone();
+    }
+}
+
+/**
  * TODO
  */
-@yamlComponent!( q{name => Assets.get!Texture( name )} )()
-class Texture : Asset
+class TextureAsset : Asset
 {
 protected:
     uint _width = 1;
@@ -152,6 +187,14 @@ private:
 }
 
 /**
+ * A reference to a texture.
+ */
+class Texture : AssetRef!TextureAsset
+{
+    alias asset this;
+}
+
+/**
  * A default black texture.
  */
 @property Texture defaultTex()
@@ -159,7 +202,7 @@ private:
     static Texture def;
 
     if( !def )
-        def = new Texture( [cast(ubyte)0, cast(ubyte)0, cast(ubyte)0, cast(ubyte)255].ptr );
+        def = new TextureAsset( [cast(ubyte)0, cast(ubyte)0, cast(ubyte)0, cast(ubyte)255].ptr );
 
     return def;
 }
@@ -172,7 +215,7 @@ private:
     static Texture def;
 
     if( !def )
-        def = new Texture( [cast(ubyte)255, cast(ubyte)127, cast(ubyte)127, cast(ubyte)255].ptr );
+        def = new TextureAsset( [cast(ubyte)255, cast(ubyte)127, cast(ubyte)127, cast(ubyte)255].ptr );
 
     return def;
 }

--- a/source/dash/components/mesh.d
+++ b/source/dash/components/mesh.d
@@ -11,13 +11,6 @@ import std.stdio, std.stream, std.format, std.math, std.string;
 
 mixin( registerComponents!q{dash.components.mesh} );
 
-/*Mesh getMesh( string name )
-{
-    auto mesh = Assets.get!Mesh( yml.get!string );
-
-    return mesh;
-}*/
-
 /**
  * Loads and manages meshes into OpenGL.
  *
@@ -342,6 +335,11 @@ public:
 class Mesh : AssetRef!MeshAsset
 {
     alias asset this;
+
+    this( MeshAsset ass )
+    {
+        super( ass );
+    }
 }
 
 /**

--- a/source/dash/components/mesh.d
+++ b/source/dash/components/mesh.d
@@ -63,7 +63,7 @@ private:
     uint _glVertexArray, _numVertices, _numIndices, _glIndexBuffer, _glVertexBuffer;
     bool _animated;
     AABB _boundingBox;
-    AssetAnimation _animationData;
+    AnimationData _animationData;
 
 public:
     /// TODO
@@ -308,7 +308,7 @@ public:
             auto tempMesh = new MeshAsset( resource.fullPath, scene.mMeshes[ 0 ] );
 
             if( scene.mNumAnimations > 0 )
-                tempMesh.animationData = new AssetAnimation( scene.mAnimations, scene.mNumAnimations, scene.mMeshes[ 0 ], scene.mRootNode );
+                tempMesh.animationData = new AnimationData( scene.mAnimations, scene.mNumAnimations, scene.mMeshes[ 0 ], scene.mRootNode );
 
             // Copy attributes
             _glVertexArray = tempMesh._glVertexArray;

--- a/source/dash/components/mesh.d
+++ b/source/dash/components/mesh.d
@@ -57,8 +57,7 @@ mixin( registerComponents!q{dash.components.mesh} );
  *  Ogre XML
  *  Q3D
  */
-@yamlComponent!( q{name => Assets.get!Mesh( name )} )()
-class Mesh : Asset
+class MeshAsset : Asset
 {
 private:
     uint _glVertexArray, _numVertices, _numIndices, _glIndexBuffer, _glVertexBuffer;
@@ -306,7 +305,7 @@ public:
         // Add mesh
         if( scene.mNumMeshes > 0 )
         {
-            Mesh tempMesh = new Mesh( resource.fullPath, scene.mMeshes[ 0 ] );
+            auto tempMesh = new MeshAsset( resource.fullPath, scene.mMeshes[ 0 ] );
 
             if( scene.mNumAnimations > 0 )
                 tempMesh.animationData = new AssetAnimation( scene.mAnimations, scene.mNumAnimations, scene.mMeshes[ 0 ], scene.mRootNode );
@@ -338,6 +337,11 @@ public:
         glDeleteBuffers( 1, &_glVertexBuffer );
         glDeleteBuffers( 1, &_glVertexArray );
     }
+}
+
+class Mesh : AssetRef!MeshAsset
+{
+    alias asset this;
 }
 
 /**

--- a/source/dash/components/userinterface.d
+++ b/source/dash/components/userinterface.d
@@ -163,7 +163,7 @@ public:
 /**
  * Creates an Awesomium web view texture
  */
-class AwesomiumView : Texture
+class AwesomiumView : TextureAsset
 {
 private:
     version( Windows )
@@ -176,7 +176,6 @@ public:
         _width = w;
         _height = h;
         glBuffer = new ubyte[_width*_height*4];
-        this.owner = owner;
 
         super( cast(ubyte*)null );
 

--- a/source/dash/core/gameobject.d
+++ b/source/dash/core/gameobject.d
@@ -199,7 +199,7 @@ public:
         _transform = Transform( this );
 
         // Create default material
-        material = new Material( "default" );
+        material = new Material( new MaterialAsset( "default" ) );
         id = nextId++;
 
         stateFlags = new ObjectStateFlags;


### PR DESCRIPTION
This reduces duplicated use of classes as assets and components, and separates the the difference between the two. This implements the [flyweight pattern](http://gameprogrammingpatterns.com/flyweight.html).

Assets are the actual data loaded from the file system (i.e. Meshes, Textures, Sounds...). There should generally only be one instance of each type for each asset. The exception here is Materials, where they should all be unique.

AssetRefs are references to the assets, and are the actual components. Each has (minimally) a reference to the asset, as well as a string that is the asset name (for serialization/deserialization purposes).
