### PR TITLE
OpenGL 3.3 Support

### DIFF
--- a/source/dash/graphics/adapters/gl.d
+++ b/source/dash/graphics/adapters/gl.d
@@ -431,7 +431,10 @@ public:
 
         glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
-        uiPass();
+        //ui is currently broken on Linux
+        //TODO: Repair the UI on Linux systems
+        version(!linux)
+                uiPass();
 
         // put it on the screen
         swapBuffers();

--- a/source/dash/graphics/adapters/gl.d
+++ b/source/dash/graphics/adapters/gl.d
@@ -433,7 +433,8 @@ public:
 
         //ui is currently broken on Linux
         //TODO: Repair the UI on Linux systems
-        version(!linux)
+        version(linux){}
+        else
                 uiPass();
 
         // put it on the screen

--- a/source/dash/graphics/adapters/sdl.d
+++ b/source/dash/graphics/adapters/sdl.d
@@ -47,8 +47,16 @@ public:
 
         window.setTitle( DGame.instance.title );
 
+    if(config.graphics.usingGl33)
+    {
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3); 
+    }
+    else
+    {
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
+    }
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
         //context = SDL_GL_CreateContext( window );

--- a/source/dash/graphics/adapters/sdl.d
+++ b/source/dash/graphics/adapters/sdl.d
@@ -47,17 +47,17 @@ public:
 
         window.setTitle( DGame.instance.title );
 
-    if(config.graphics.usingGl33)
-    {
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3); 
-    }
-    else
-    {
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
-    }
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        if(config.graphics.usingGl33)
+        {
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3); 
+        }
+        else
+        {
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
+        }
+                SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
         string iconPath = Resources.Textures ~ "/icon.bmp";
 

--- a/source/dash/graphics/shaders/shaders.d
+++ b/source/dash/graphics/shaders/shaders.d
@@ -141,7 +141,7 @@ private:
     uint _programID, _vertexShaderID, _fragmentShaderID;
     string _shaderName;
     auto versionRegex = ctRegex!r"\#version\s400";
-    auto layoutRegex = ctRegex!r"layout\(location\s\=\s[0-9]\)\s";
+    auto layoutRegex = ctRegex!r"layout\(location\s\=\s[0-9]+\)\s";
 
 public:
     /// The program ID for the shader

--- a/source/dash/utility/config.d
+++ b/source/dash/utility/config.d
@@ -67,8 +67,8 @@ public:
         bool backfaceCulling = true;
         @rename( "VSync" ) @optional
         bool vsync = false;
-        @rename( "OpenGL3.3" ) @optional
-	    bool usingGl33 = false;
+        @rename( "OpenGL33" ) @optional
+        bool usingGl33 = false;
     }
 
     static struct UserInterfaceSettings

--- a/source/dash/utility/config.d
+++ b/source/dash/utility/config.d
@@ -67,6 +67,8 @@ public:
         bool backfaceCulling = true;
         @rename( "VSync" ) @optional
         bool vsync = false;
+        @rename( "OpenGL3.3" ) @optional
+	    bool usingGl33 = false;
     }
 
     static struct UserInterfaceSettings


### PR DESCRIPTION
Title says it all. We use regex to remove layout qualifiers from our shader strings before compilation according to the Graphics/"OpenGL3.3" flag in the configuration file.

Also disabled rendering the ui on Linux until we get that fixed.
