### PR TITLE
Feature: std.experimental.logger 

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -22,8 +22,9 @@
         "derelict-assimp3": "~>1.0",
         "dyaml": "~>0.5",
         "gl3n": "==1.0.0",
-        "gfm:sdl2": "==1.3.3",
-        "dlogg": "~>0.3",
+        "gfm:sdl2": "==1.3.8",
+        "logger": "==0.3.3",
+        "colorize":  "==1.0.5",
         "msgpack-d": "==0.9.2",
         "vibe-d": "0.7.21-rc.4",
         "x11": { "version": "~>1.0", "optional": true }

--- a/source/dash/components/animation.d
+++ b/source/dash/components/animation.d
@@ -120,7 +120,7 @@ public:
             _currentAnimTime = startAnimTime;
         }
         else
-            logWarning( "Could not change to new animation, the animation did not exist." );
+            warning( "Could not change to new animation, the animation did not exist." );
     }
     /**
     * Runs an animation once, then returns
@@ -135,7 +135,7 @@ public:
             _currentAnimTime = 0;
         }
         else
-            logWarning( "Could not change to new animation, the animation did not exist." );
+            warning( "Could not change to new animation, the animation did not exist." );
     }
 
     /**

--- a/source/dash/components/assets.d
+++ b/source/dash/components/assets.d
@@ -53,7 +53,7 @@ public:
                 }
                 else
                 {
-                    logFatal( "Unable to find ", name, " in $array." );
+                    errorf( "Unable to find %s in $array.", name );
                     return null;
                 }
             }
@@ -94,7 +94,7 @@ public:
             if( scene.mNumMeshes > 0 )
             {
                 if( file.baseFileName in meshes )
-                    logWarning( "Mesh ", file.baseFileName, " exsists more than once." );
+                    warning( "Mesh ", file.baseFileName, " exsists more than once." );
 
                 auto newMesh = new MeshAsset( file, scene.mMeshes[ 0 ] );
 
@@ -105,7 +105,7 @@ public:
             }
             else
             {
-                logWarning( "Assimp did not contain mesh data, ensure you are loading a valid mesh." );
+                warning( "Assimp did not contain mesh data, ensure you are loading a valid mesh." );
             }
 
             // Release mesh
@@ -115,7 +115,7 @@ public:
         foreach( file; scanDirectory( Resources.Textures ) )
         {
             if( file.baseFileName in textures )
-               logWarning( "Texture ", file.baseFileName, " exists more than once." );
+               warningf( "Texture %s exists more than once.", file.baseFileName );
 
             textures[ file.baseFileName ] = new TextureAsset( file );
         }
@@ -127,7 +127,7 @@ public:
             foreach( mat; newMat )
             {
                 if( mat.name in materials )
-                    logWarning( "Material ", mat.name, " exists more than once." );
+                    warningf( "Material %s exists more than once.", mat.name );
 
                 mat.resource = res;
                 materials[ mat.name ] = mat;
@@ -157,7 +157,7 @@ public:
                 }
                 else if( asset.resource.needsRefresh )
                 {
-                    logDebug( "Refreshing ", name, "." );
+                    tracef( "Refreshing %s.", name );
                     asset.refresh();
                 }
             }
@@ -179,7 +179,7 @@ public:
             foreach_reverse( name; $aaName.keys )
             {
                 if( !$aaName[ name ].isUsed )
-                    logWarning( "$friendlyName ", name, " not used during this run." );
+                    warningf( "$friendlyName %s not used during this run.", name );
 
                 $aaName[ name ].shutdown();
                 $aaName.remove( name );

--- a/source/dash/components/component.d
+++ b/source/dash/components/component.d
@@ -165,7 +165,7 @@ public:
             }
             else
             {
-                logError( "Description of type ", typeid(this).name, " not found! Did you forget a mixin(registerComponents!())?" );
+                errorf( "Description of type %s not found! Did you forget a mixin(registerComponents!())?", typeid(this).name );
                 return $type();
             }
         }
@@ -185,13 +185,13 @@ public:
                 }
                 else
                 {
-                    logWarning( "Component's \"Type\" not found: ", type.get!string );
+                    warningf( "Component's \"Type\" not found: %s", type.get!string );
                     return null;
                 }
             }
             else
             {
-                logWarning( "Component doesn't have \"Type\" field." );
+                warningf( "Component doesn't have \"Type\" field." );
                 return null;
             }
         }

--- a/source/dash/components/lights.d
+++ b/source/dash/components/lights.d
@@ -104,7 +104,7 @@ public:
             // check for success
             if( glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE )
             {
-                logFatal("Shadow map frame buffer failure.");
+                fatal( "Shadow map frame buffer failure." );
                 assert(false);
             }
         }

--- a/source/dash/components/mesh.d
+++ b/source/dash/components/mesh.d
@@ -131,7 +131,7 @@ public:
                 }
                 if( maxBonesAttached > 4 )
                 {
-                    logWarning( filePath, " has more than 4 bones for some vertex, data will be truncated. (has ", maxBonesAttached, ")" );
+                    warningf( "%s has more than 4 bones for some vertex, data will be truncated. (has %s)", filePath, maxBonesAttached );
                 }
 
                 // For each vertex on each face
@@ -221,7 +221,7 @@ public:
         else
         {
             // Did not load
-            logFatal( "Mesh not loaded: ", filePath );
+            fatalf( "Mesh not loaded: %s", filePath );
         }
 
         // make and bind the VAO
@@ -311,7 +311,7 @@ public:
         }
         else
         {
-            logWarning( "Assimp did not contain mesh data, ensure you are loading a valid mesh." );
+            warning( "Assimp did not contain mesh data, ensure you are loading a valid mesh." );
             return;
         }
 

--- a/source/dash/components/userinterface.d
+++ b/source/dash/components/userinterface.d
@@ -43,7 +43,7 @@ public:
         {
             _view = new AwesomiumView( w, h, filePath, null );
         }
-        logDebug( "UI File: ", filePath );
+        tracef( "UI File: %s", filePath );
     }
 
     /**

--- a/source/dash/core/dgame.d
+++ b/source/dash/core/dgame.d
@@ -203,9 +203,8 @@ private:
         stateFlags = new GameStateFlags;
         stateFlags.resumeAll();
 
-        logDebug( "Initializing..." );
         bench!( { Config.initialize(); } )( "Config init" );
-        bench!( { Logger.initialize(); } )( "Logger init" );
+        bench!( { DashLogger.initialize(); } )( "Logger init" );
         bench!( { Input.initialize(); } )( "Input init" );
         bench!( { Graphics.initialize(); } )( "Graphics init" );
         bench!( { Assets.initialize(); } )( "Assets init" );

--- a/source/dash/core/prefabs.d
+++ b/source/dash/core/prefabs.d
@@ -30,7 +30,7 @@ public:
             }
             else
             {
-                logWarning( "Prefab ", index, " not found." );
+                warningf( "Prefab %s not found.", index );
                 return null;
             }
         }

--- a/source/dash/editor/editor.d
+++ b/source/dash/editor/editor.d
@@ -136,7 +136,7 @@ public:
             }
             catch( JSONException e )
             {
-                logError( "Error deserializing received message with key \"", key, "\" to ", DataType.stringof, ": ", e.msg );
+                errorf( "Error deserializing received message with key \"%s\" to %s: %s", key, DataType.stringof, e.msg );
                 return;
             }
 
@@ -239,7 +239,7 @@ protected:
             }
             else
             {
-                logWarning( "Invalid editor event received with key ", event.key );
+                warningf( "Invalid editor event received with key %s", event.key );
             }
         }
     }
@@ -295,7 +295,7 @@ package:
         }
         else
         {
-            logFatal( "Callback reference lost: ", msg.callbackId );
+            errorf( "Callback reference lost: %s", msg.callbackId );
         }
     }
 

--- a/source/dash/editor/websockets.d
+++ b/source/dash/editor/websockets.d
@@ -52,18 +52,18 @@ public:
             try msg = jsonStr.deserializeJson!EventMessage();
             catch( JSONException e )
             {
-                logError( "Invalid json string sent: ", jsonStr );
+                errorf( "Invalid json string sent: %s", jsonStr );
                 continue;
             }
 
             if( msg.key.length == 0 )
             {
-                logWarning( "Received a packet without a \"key.\"" );
+                warning( "Received a packet without a \"key.\"" );
                 continue;
             }
             if( msg.value.type == Json.Type.null_ || msg.value.type == Json.Type.undefined )
             {
-                logWarning( "Received a packet without a \"value.\"" );
+                warning( "Received a packet without a \"value.\"" );
                 continue;
             }
 

--- a/source/dash/graphics/adapters/gl.d
+++ b/source/dash/graphics/adapters/gl.d
@@ -70,7 +70,7 @@ public:
                 }
             }
 
-            logFatal( "Deffered rendering Frame Buffer was not initialized correctly. Error: ", mapFramebufferError(status) );
+            fatalf( "Deffered rendering Frame Buffer was not initialized correctly. Error: %s", mapFramebufferError(status) );
             assert(false);
         }
     }
@@ -136,7 +136,7 @@ public:
     {
         if( !DGame.instance.activeScene )
         {
-            logWarning( "No active scene." );
+            warning( "No active scene." );
             return;
         }
 
@@ -144,7 +144,7 @@ public:
 
         if( !scene.camera )
         {
-            logWarning( "No camera on active scene." );
+            warning( "No camera on active scene." );
             return;
         }
 
@@ -313,7 +313,7 @@ public:
 
                 if( !ambientLights.empty )
                 {
-                    logWarning( "Only one ambient light per scene is utilized." );
+                    warning( "Only one ambient light per scene is utilized." );
                 }
             }
 

--- a/source/dash/graphics/adapters/sdl.d
+++ b/source/dash/graphics/adapters/sdl.d
@@ -49,25 +49,27 @@ public:
 
         if(config.graphics.usingGl33)
         {
-                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3); 
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3); 
         }
         else
         {
-                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
-                SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
         }
-                SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
         string iconPath = Resources.Textures ~ "/icon.bmp";
 
         if( exists( iconPath ) )
         {
-                SDLImage imageLib = new SDLImage( sdl, 0 );
-                window.setIcon( imageLib.load( iconPath ) );
+            SDLImage imageLib = new SDLImage( sdl, 0 );
+            window.setIcon( imageLib.load( iconPath ) );
         }
         else
-                logDebug("Could not find icon.bmp in Textures folder!");
+        {
+            trace("Could not find icon.bmp in Textures folder!");
+        }
 
         //context = SDL_GL_CreateContext( window );
         glContext = new SDL2GLContext( window );
@@ -77,13 +79,13 @@ public:
 
         if(config.graphics.vsync)
         {
-                SDL_GL_SetSwapInterval(1); 
-                logDebug("vsync enabled!");
+            SDL_GL_SetSwapInterval(1); 
+            trace("vsync enabled!");
         }
         else
         {
-                SDL_GL_SetSwapInterval(0); 
-                logDebug("vsync disabled!");
+            SDL_GL_SetSwapInterval(0); 
+            trace("vsync disabled!");
         }
     }
 

--- a/source/dash/graphics/adapters/win32gl.d
+++ b/source/dash/graphics/adapters/win32gl.d
@@ -126,7 +126,7 @@ public:
 
         if( DerelictGL3.loadedVersion < GLVersion.GL40 )
         {
-            logFatal( "Your version of OpenGL is unsupported. Required: GL40 Yours: ", DerelictGL3.loadedVersion );
+            fatalf( "Your version of OpenGL is unsupported. Required: GL40 Yours: %s", DerelictGL3.loadedVersion );
             //throw new Exception( "Unsupported version of OpenGL." );
             return;
         }

--- a/source/dash/graphics/shaders/shaders.d
+++ b/source/dash/graphics/shaders/shaders.d
@@ -179,13 +179,13 @@ public:
             //aren't supported in GLSL 330)
             if(config.graphics.usingGl33)
             {
-                    vertexBody = replaceAll(vertexBody, layoutRegex, ""); 
-                    vertexBody = replaceAll(vertexBody, versionRegex, "#version 330"); 
+                vertexBody = replaceAll(vertexBody, layoutRegex, ""); 
+                vertexBody = replaceAll(vertexBody, versionRegex, "#version 330"); 
 
-                    fragmentBody = replaceAll(fragmentBody, layoutRegex, ""); 
-                    fragmentBody = replaceAll(fragmentBody, versionRegex, "#version 330"); 
+                fragmentBody = replaceAll(fragmentBody, layoutRegex, ""); 
+                fragmentBody = replaceAll(fragmentBody, versionRegex, "#version 330"); 
 
-                    logDebug( vertexBody );
+                trace( vertexBody );
             }
 
             compile( vertexBody, fragmentBody );
@@ -229,11 +229,11 @@ public:
         glGetShaderiv( vertexShaderID, GL_COMPILE_STATUS, &compileStatus );
         if( compileStatus != GL_TRUE )
         {
-            logFatal( shaderName ~ " Vertex Shader compile error" );
+            errorf( "%s Vertex Shader compile error", shaderName );
             char[1000] errorLog;
             auto info = errorLog.ptr;
             glGetShaderInfoLog( vertexShaderID, 1000, null, info );
-            logFatal( errorLog );
+            error( errorLog );
             assert(false);
         }
 
@@ -241,11 +241,11 @@ public:
         glGetShaderiv( fragmentShaderID, GL_COMPILE_STATUS, &compileStatus );
         if( compileStatus != GL_TRUE )
         {
-            logFatal( shaderName ~ " Fragment Shader compile error" );
+            errorf( "%s Fragment Shader compile error", shaderName );
             char[1000] errorLog;
             auto info = errorLog.ptr;
             glGetShaderInfoLog( fragmentShaderID, 1000, null, info );
-            logFatal( errorLog );
+            error( errorLog );
             assert(false);
         }
 
@@ -257,11 +257,11 @@ public:
         glGetProgramiv( programID, GL_LINK_STATUS, &compileStatus );
         if( compileStatus != GL_TRUE )
         {
-            logFatal( shaderName ~ " Shader program linking error" );
+            errorf( "%s Shader program linking error", shaderName );
             char[1000] errorLog;
             auto info = errorLog.ptr;
             glGetProgramInfoLog( programID, 1000, null, info );
-            logFatal( errorLog );
+            error( errorLog );
             assert(false);
         }
     }

--- a/source/dash/utility/config.d
+++ b/source/dash/utility/config.d
@@ -4,6 +4,7 @@
 module dash.utility.config;
 import dash.utility.resources, dash.utility.output, dash.utility.data;
 
+import std.experimental.logger;
 import std.datetime;
 
 /**
@@ -36,18 +37,25 @@ public:
     static struct LoggerSettings
     {
         @rename( "FilePath" ) @optional
-        string filePath = null;
+        string filePath = "dash.log";
         @rename( "Debug" ) @optional
-        Verbosities debug_ = Verbosities( Verbosity.Debug, Verbosity.Debug );
+        Verbosities debug_ = Verbosities( LogLevel.all, LogLevel.all );
         @rename( "Release" ) @optional
-        Verbosities release = Verbosities( Verbosity.Off, Verbosity.High );
+        Verbosities release = Verbosities( LogLevel.off, LogLevel.error );
+
+        @ignore
+        Verbosities verbosities() const @property pure @safe nothrow @nogc
+        {
+            debug return debug_;
+            else  return release;
+        }
 
         static struct Verbosities
         {
             @rename( "OutputVerbosity" ) @optional @byName
-            Verbosity outputVerbosity = Verbosity.Low;
+            LogLevel outputVerbosity = LogLevel.info;
             @rename( "LoggingVerbosity" ) @optional @byName
-            Verbosity loggingVerbosity = Verbosity.Debug;
+            LogLevel loggingVerbosity = LogLevel.all;
         }
     }
 

--- a/source/dash/utility/data/serialization.d
+++ b/source/dash/utility/data/serialization.d
@@ -88,7 +88,7 @@ T deserializeFile( T )( Resource file, SerializationMode mode = SerializationMod
     }
     catch( Exception e )
     {
-        logError( "Error deserializing file ", file.fileName, " to type ", T.stringof, ". ", e.msg );
+        errorf( "Error deserializing file %s to type %s: %s", file.fileName, T.stringof, e.msg );
         return T.init;
     }
 }
@@ -146,7 +146,7 @@ T[] deserializeMultiFile( T )( Resource file, SerializationMode mode = Serializa
     }
     catch( Exception e )
     {
-        logError( "Error deserializing file ", file.fileName, " to type ", T.stringof, ". ", e.msg );
+        errorf( "Error deserializing file %s to type %s: %s", file.fileName, T.stringof, e.msg );
         return [];
     }
 }
@@ -201,7 +201,7 @@ template serializeToFile( bool prettyPrint = true )
         }
         catch( Exception e )
         {
-            logError( "Error serializing ", T.stringof, " to file ", file.fileName, ". ", e.msg );
+            errorf( "Error serializing %s to file %s: %s", T.stringof, file.fileName, e.msg );
         }
     }
 }

--- a/source/dash/utility/input/input.d
+++ b/source/dash/utility/input/input.d
@@ -63,7 +63,7 @@ public:
         }
         catch( Exception e )
         {
-            logError( "Error parsing config file:\n", e.toString() );
+            errorf( "Error parsing config file:%s\n", e.toString() );
         }
 
         Keyboard.initialize();
@@ -341,7 +341,7 @@ public:
     {
         if( !DGame.instance.activeScene )
         {
-            logWarning( "No active scene." );
+            warning( "No active scene." );
             return vec3f( 0.0f, 0.0f, 0.0f );
         }
 
@@ -349,7 +349,7 @@ public:
 
         if( !scene.camera )
         {
-            logWarning( "No camera on active scene." );
+            warning( "No camera on active scene." );
             return vec3f( 0.0f, 0.0f, 0.0f );
         }
         vec2ui mouse = mousePos();
@@ -394,7 +394,7 @@ public:
     {
         if( !DGame.instance.activeScene )
         {
-            logWarning( "No active scene." );
+            warning( "No active scene." );
             return null;
         }
 
@@ -402,7 +402,7 @@ public:
 
         if( !scene.camera )
         {
-            logWarning( "No camera on active scene." );
+            warning( "No camera on active scene." );
             return null;
         }
 

--- a/source/dash/utility/output.d
+++ b/source/dash/utility/output.d
@@ -2,7 +2,9 @@
  * Defines the Dash logger, using the std.logger proposal.
  */
 module dash.utility.output;
-public import std.experimental.logger;
+import std.experimental.logger;
+// Logging functions for the others
+public import std.experimental.logger: log, logf, trace, tracef, info, infof, warning, warningf, error, errorf, critical, criticalf, fatal, fatalf;
 
 import colorize;
 

--- a/source/dash/utility/resources.d
+++ b/source/dash/utility/resources.d
@@ -36,7 +36,7 @@ Resource[] scanDirectory( string path, string pattern = "" )
 
     if( !safePath.exists() )
     {
-        logDebug( path, " does not exist." );
+        tracef( "%s does not exist.", path );
         return [];
     }
 

--- a/source/dash/utility/time.d
+++ b/source/dash/utility/time.d
@@ -106,7 +106,7 @@ void updateTime()
     second += delta;
     if( second >= 1.seconds )
     {
-        logDebug( "Framerate: ", frameCount );
+        tracef( "Framerate: %d", frameCount );
         second = Duration.zero;
         frameCount = 0;
     }


### PR DESCRIPTION
dash.utility.output now implements the std.experimental.logger standard, meaning that we'll be ready to start using it as soon as it's merged into phobos. This also gives us the added benefit of the fact that all logging functions now come with an `f` variant, which behaves like `printf`. The only downside is that someone (probably me) will have to go through and change all calls to `logInfo` to `info`, `logError` to `error`, etc., which will be a lot of busy work. I will go ahead and do that though, if you guys think it's something you'd like to see.
